### PR TITLE
Allow configuration value for MultiSubnetFailover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 target
 *.log
+
+.settings
+.project
+.classpath

--- a/kafka-connect-cdc/src/main/java/com/github/jcustenborder/kafka/connect/cdc/PooledCDCSourceConnectorConfig.java
+++ b/kafka-connect-cdc/src/main/java/com/github/jcustenborder/kafka/connect/cdc/PooledCDCSourceConnectorConfig.java
@@ -40,6 +40,9 @@ public abstract class PooledCDCSourceConnectorConfig<T extends ConnectionPoolDat
   static final String JDBC_POOL_MIN_IDLE_CONF = "jdbc.pool.min.idle";
   static final String JDBC_POOL_MIN_IDLE_DOC = "The minimum number of idle CONNECTIONS in the connection pool.";
 
+  static final String MULTI_SUBNET_FAILOVER_CONF = "multi.subnet.failover";
+  static final String MULTI_SUBNET_FAILOVER_DOC = "Use High Availability MultiSubnetFailover (true/false)";
+
   public final String serverName;
   public final int serverPort;
   public final String initialDatabase;
@@ -49,6 +52,7 @@ public abstract class PooledCDCSourceConnectorConfig<T extends ConnectionPoolDat
   public final int jdbcPoolMaxTotal;
   public final int jdbcPoolMaxIdle;
   public final int jdbcPoolMinIdle;
+  public final Boolean multiSubnetFailover;
 
 
   public PooledCDCSourceConnectorConfig(ConfigDef definition, Map<?, ?> originals) {
@@ -61,6 +65,7 @@ public abstract class PooledCDCSourceConnectorConfig<T extends ConnectionPoolDat
     this.serverName = this.getString(SERVER_NAME_CONF);
     this.serverPort = this.getInt(SERVER_PORT_CONF);
     this.initialDatabase = this.getString(INITIAL_DATABASE_CONF);
+    this.multiSubnetFailover = this.getBoolean(MULTI_SUBNET_FAILOVER_CONF);
   }
 
   public static ConfigDef config() {
@@ -72,7 +77,8 @@ public abstract class PooledCDCSourceConnectorConfig<T extends ConnectionPoolDat
         .define(JDBC_PASSWORD_CONF, ConfigDef.Type.PASSWORD, ConfigDef.Importance.HIGH, JDBC_PASSWORD_DOC)
         .define(JDBC_POOL_MAX_TOTAL_CONF, ConfigDef.Type.INT, 30, ConfigDef.Importance.MEDIUM, JDBC_POOL_MAX_TOTAL_DOC)
         .define(JDBC_POOL_MAX_IDLE_CONF, ConfigDef.Type.INT, 10, ConfigDef.Importance.MEDIUM, JDBC_POOL_MAX_IDLE_DOC)
-        .define(JDBC_POOL_MIN_IDLE_CONF, ConfigDef.Type.INT, 3, ConfigDef.Importance.MEDIUM, JDBC_POOL_MIN_IDLE_DOC);
+        .define(JDBC_POOL_MIN_IDLE_CONF, ConfigDef.Type.INT, 3, ConfigDef.Importance.MEDIUM, JDBC_POOL_MIN_IDLE_DOC)
+        .define(MULTI_SUBNET_FAILOVER_CONF, ConfigDef.Type.BOOLEAN, ConfigDef.Importance.LOW, MULTI_SUBNET_FAILOVER_DOC);
   }
 
   public abstract T connectionPoolDataSourceFactory();


### PR DESCRIPTION
This allows a user to include the config value to enable MultiSubnetFailover. There will be a corresponding addition to [kafka-connect-cdc-mssql](https://github.com/jcustenborder/kafka-connect-cdc-mssql) to add the setting to the connection.

The slight change in the `.gitignore`  is due to auto created files in VSCode.